### PR TITLE
Make it able to commit to book-preview

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -19,7 +19,8 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/book-preview
           path: preview
-          ssh-key: ${{ secrets.PREVIEW_KEY }}
+          token: ${{ secrets.PREVIEW_KEY }}
+          
       - name: Build
         run: |
           rm -r preview/${{ github.event.number }} || true


### PR DESCRIPTION
You were mistakenly using the `ssh-key` in `actions/checkout`. I have changed it to token. It now successfully commits to book-preview. 